### PR TITLE
Fix the config naming issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ function BlindsAccessory(log, config) {
   this.durationDown = config['durationDown'];
   this.durationOffset = config['durationOffset'];
   this.mqttUrl = config['mqttUrl'] || 'mqtt://localhost:1883';
-  this.mqttUser = config['user'] || '';
-  this.mqttPass = config['pass'] || '';
+  this.mqttUser = config['mqttUser'] || '';
+  this.mqttPass = config['mqttPass'] || '';
 
   this.cacheDirectory = HomebridgeAPI.user.persistPath();
   this.storage = require('node-persist');


### PR DESCRIPTION
In the readme it say's mqttUser and mqttPass while in the code it self it's referring to User and Pass without mqtt before.